### PR TITLE
Explicitly include README.rst and LICENSE in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
+include README.rst
+include LICENSE
 include *.pyx *.pxd *.cpp
 include tests/*.py


### PR DESCRIPTION
This makes the source tarball on PyPI fit for packaging it for distributions
(Ubuntu, Debian, ...).