### PR TITLE
Update Tesseract 4 API

### DIFF
--- a/tesseract4.pxd
+++ b/tesseract4.pxd
@@ -178,7 +178,7 @@ cdef extern from "tesseract/renderer.h" namespace "tesseract" nogil:
         TessHOcrRenderer(cchar_t *, bool) except +
 
     cdef cppclass TessPDFRenderer(TessResultRenderer):
-        TessPDFRenderer(cchar_t *, cchar_t *) except +
+        TessPDFRenderer(cchar_t *, cchar_t *, bool) except +
 
     cdef cppclass TessUnlvRenderer(TessResultRenderer):
         TessUnlvRenderer(cchar_t *) except +

--- a/tesserocr.pyx
+++ b/tesserocr.pyx
@@ -1880,6 +1880,7 @@ cdef class PyTessBaseAPI:
         cdef:
             bool b
             bool font_info
+            bool textonly            
             TessResultRenderer *temp
             TessResultRenderer *renderer = NULL
 
@@ -1895,7 +1896,8 @@ cdef class PyTessBaseAPI:
 
         self._baseapi.GetBoolVariable("tessedit_create_pdf", &b)
         if b:
-            temp = new TessPDFRenderer(outputbase, self._baseapi.GetDatapath())
+            self._baseapi.GetBoolVariable("textonly_pdf", &textonly)
+            temp = new TessPDFRenderer(outputbase, self._baseapi.GetDatapath(), textonly)
             if renderer == NULL:
                 renderer = temp
             else:

--- a/tesserocr.pyx
+++ b/tesserocr.pyx
@@ -1880,7 +1880,8 @@ cdef class PyTessBaseAPI:
         cdef:
             bool b
             bool font_info
-            bool textonly            
+            IF TESSERACT_VERSION >= 0x040000:
+                bool textonly
             TessResultRenderer *temp
             TessResultRenderer *renderer = NULL
 
@@ -1896,8 +1897,12 @@ cdef class PyTessBaseAPI:
 
         self._baseapi.GetBoolVariable("tessedit_create_pdf", &b)
         if b:
-            self._baseapi.GetBoolVariable("textonly_pdf", &textonly)
-            temp = new TessPDFRenderer(outputbase, self._baseapi.GetDatapath(), textonly)
+            IF TESSERACT_VERSION >= 0x040000:
+                self._baseapi.GetBoolVariable("textonly_pdf", &textonly)
+                temp = new TessPDFRenderer(outputbase, self._baseapi.GetDatapath(), textonly)
+            ELSE:
+                temp = new TessPDFRenderer(outputbase, self._baseapi.GetDatapath())
+
             if renderer == NULL:
                 renderer = temp
             else:


### PR DESCRIPTION
The API for TessPDFRendererCreate was changed about 9 days ago. I updated the tesserocr files to reflect the new changes which fixes compilation errors that popped up as a result. I've linked the relevant changes below for reference.

https://github.com/tesseract-ocr/tesseract/commit/8ce58ac458c78fa84ff77d2d74a3f51c2e5bd0a9#diff-1ff9fac4997a03321dc873248bcf1309

https://github.com/tesseract-ocr/tesseract/commit/effa5741e6ef8bcb37d68250ca39c92fae85f6a9#diff-0b21ad820cf950ff83875c63e6309107