### PR TITLE
Fix setup.py detecting Tesseract 4 as Tesseract 3 in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,9 +96,9 @@ def get_tesseract_version():
     try:
         p = subprocess.Popen(['tesseract', '-v'], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         stdout_version, version = p.communicate()
-        if version == '':
-            version = stdout_version
         version = _read_string(version).strip()
+        if version == '':
+            version = _read_string(stdout_version).strip()
         version_match = re.search(r'^tesseract ((?:\d+\.)+\d+).*', version, re.M)
         if version_match:
             version = version_match.group(1)


### PR DESCRIPTION
In Python 3, Popen.communicate() returns bytes strings, not literal strings. Therefore this comparison is necessary to avoid a bad detection of the version.

Python 3.6

    >>> from subprocess import Popen, PIPE
    >>> example = Popen(['ls'], stdout=PIPE)
    >>> std, err = example.communicate()
    >>> type(std)
    <class 'bytes'>
    >>> b'' == ''
    False

Python 2.7

    >>> from subprocess import Popen, PIPE
    >>> example = Popen(['ls'], stdout=PIPE)
    >>> std, err = example.communicate()
    >>> type(std)
    <type 'str'>
    >>> b'' == ''
    True
