### PR TITLE
added Windows installation to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,8 @@ case you have multiple tesseract/leptonica installations.
 
 Installation
 ============
-
+Linux and BSD/MacOS
+-------------------
 ::
 
     $ pip install tesserocr
@@ -73,6 +74,26 @@ Tested on Linux and BSD/MacOS
 
 .. |pkg-config| replace:: **pkg-config**
 .. _pkg-config: https://pkgconfig.freedesktop.org/
+
+Windows
+-------
+The proposed downloads consist of stand-alone packages containing all the Windows libraries needed for execution. This means that no additional installation of tesseract is required on your system.
+
+Conda
+`````
+You can use the channel `simonflueckiger <https://anaconda.org/simonflueckiger/tesserocr>`_ to install from Conda:
+::
+    > conda install -c simonflueckiger tesserocr
+
+or to get **tesserocr** compiled with **tesseract 4.0.0**:
+::
+    > conda install -c simonflueckiger/label/tesseract-4.0.0-master tesserocr
+
+pip
+```
+Download the wheel file corresponding to your windows platform and python installation from `simonflueckiger/tesserocr-windows_build/releases <https://github.com/simonflueckiger/tesserocr-windows_build/releases>`_ and install them via:
+::
+    > pip install <package_name>.whl
 
 Usage
 =====

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ or to get **tesserocr** compiled with **tesseract 4.0.0**:
 
 pip
 ```
-Download the wheel file corresponding to your windows platform and python installation from `simonflueckiger/tesserocr-windows_build/releases <https://github.com/simonflueckiger/tesserocr-windows_build/releases>`_ and install them via:
+Download the wheel file corresponding to your Windows platform and Python installation from `simonflueckiger/tesserocr-windows_build/releases <https://github.com/simonflueckiger/tesserocr-windows_build/releases>`_ and install them via:
 ::
     > pip install <package_name>.whl
 


### PR DESCRIPTION
My Windows all-inclusive build has gained a lot of traction during the past couple of months. It is currently only linked on issue #19 ([here](https://github.com/sirfz/tesserocr/issues/19#issuecomment-335875716) and [here](https://github.com/sirfz/tesserocr/issues/19#issuecomment-374881553)). I typed up a short `Windows installation` section for the README to make **tesserocr** even more accessible to Windows users. What do you think? I'm looking forward to your feedback.