### PR TITLE
Fix version handling for new versioning scheme of tesseract

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ else:
 
 def version_to_int(version):
     version = re.search(r'((?:\d+\.)+\d+)', version).group()
-    return int(''.join(version.split('.')), 16)
+    # Split the groups on ".", take only the first one, and print each group with leading 0 if needed
+    version_str = "{:02}{:02}{:02}".format(*map(int, version.split('.')[:3]))
+    return int(version_str, 16)
 
 
 def package_config():

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,9 @@ else:
 def version_to_int(version):
     version = re.search(r'((?:\d+\.)+\d+)', version).group()
     # Split the groups on ".", take only the first one, and print each group with leading 0 if needed
-    version_str = "{:02}{:02}{:02}".format(*map(int, version.split('.')[:3]))
+    # To be safe, also handle cases where an extra group is added to the version string, or if one or two groups
+    # are dropped.
+    version_str = "{:02}{:02}{:02}".format(*map(int, (version.split('.') + [0]*2)[:3]))
     return int(version_str, 16)
 
 


### PR DESCRIPTION
The version conversion to int is currently broken with the new tesseract versioning scheme which has removed the "0 padding" of the version fields, e.g. it is currently "4.0.0-beta1" rather than "4.00.00-alpha". So the latest 4.x version are detected as 3.x and are not compiling.

With this the detection should work again to detect tesseract 4.x.

 