### PR TITLE
fix for _DEFAULT_LANG not being set

### DIFF
--- a/tesserocr.pyx
+++ b/tesserocr.pyx
@@ -49,7 +49,10 @@ cdef TessBaseAPI _api = TessBaseAPI()
 _api.SetVariable('debug_file', '/dev/null')  # suppress tesseract debug messages
 _api.Init(NULL, NULL)
 cdef _DEFAULT_PATH = abspath(join(_api.GetDatapath(), os.pardir)) + os.sep
-cdef _DEFAULT_LANG = _api.GetInitLanguagesAsString()
+_init_lang = _api.GetInitLanguagesAsString()
+if _init_lang == '':
+    _init_lang = 'eng'
+cdef _DEFAULT_LANG = _init_lang
 _api.End()
 TessBaseAPI.ClearPersistentCache()
 


### PR DESCRIPTION
### short version
If tesseract doesn't find a valid tessdata path during _api.Init(NULL, NULL), TessBaseAPI::GetInitLanguagesAsString() will return the empty string. This breaks PyTessBaseAPI(path=path/to/valid/tessdata/location) initialization since the default argument lang=_DEFAULT_LANG (which was set to '') is not a valid language.

### extended version
Assumption: we moved our tessdata folder to some funky location where tesseract's [CCUtil::main_setup](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/ccutil/mainblk.cpp) couldn't possibly find it.

In order to get the tessdata path and the default language provided by tesseract, tesserocr initializes the api with both the tessdata path as well as the language string set to `NULL`

[tesserocr/tesserocr.pyx#L50](https://github.com/sirfz/tesserocr/blob/c40692c52cde8a25693aeb6acf1af02b34d0156b/tesserocr.pyx#L50)
```c++
_api.Init(NULL, NULL)
```

and the default language string `"eng"` is successfully assigned to `language` in the file `tesseract/api/baseapi.cpp`

[tesseract/api/baseapi.cpp#L345](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/api/baseapi.cpp#L345):
```Cython
  if (language == nullptr) language = "eng";
```

however, far down the rabbit hole, tesseract fails to load the actual `eng.traineddata` resulting in `Init(tessdata_path.string())` being false.

[tesseract/ccmain/tessedit.cpp#L108](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/ccmain/tessedit.cpp#L108):
```c++
  if (!mgr->is_loaded() && !mgr->Init(tessdata_path.string())) {
    tprintf("Error opening data file %s\n", tessdata_path.string());
    tprintf("Please make sure the TESSDATA_PREFIX environment variable is set"
            " to your \"tessdata\" directory.\n");
    return false;
  }
```

This forces its caller functions to send the failed initialization up the stack.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&downarrow;
[tesseract/ccmain/tessedit.cpp#L393](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/ccmain/tessedit.cpp#L393)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&downarrow;
[tesseract/ccmain/tessedit.cpp#L341](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/ccmain/tessedit.cpp#L341)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&downarrow;
[tesseract/api/baseapi.cpp#L379](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/api/baseapi.cpp#L379)

and we're back in `tesseract/api/baseapi.cpp` where the failed initialization forces the function to return prematurely, thus preventing setting `language_` a couple of lines later

[tesseract/api/baseapi.cpp#L393](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/api/baseapi.cpp#L393):
```c++
  if (language_ == nullptr)
    language_ = new STRING(language);
```

So now when `_api.GetInitLanguagesAsString()` gets called in

[tesserocr/tesserocr.pyx#L52](https://github.com/sirfz/tesserocr/blob/c40692c52cde8a25693aeb6acf1af02b34d0156b/tesserocr.pyx#L52)
```Cython
cdef _DEFAULT_LANG = _api.GetInitLanguagesAsString()
```
it will return the empty string, since

[tesseract/api/baseapi.cpp#L415](https://github.com/tesseract-ocr/tesseract/blob/a07ee5c40bf958de26ba46175f97f23fe9e5fc2b/api/baseapi.cpp#L415):
```c++
const char* TessBaseAPI::GetInitLanguagesAsString() const {
  return (language_ == NULL || language_->string() == NULL) ? "" : language_->string();
}
```

Finally, As soon as the api gets initialized via `PyTessBaseAPI(path=path/to/valid/tessdata/location)`...

[tesserocr/tesserocr.pyx#L1357](https://github.com/sirfz/tesserocr/blob/c40692c52cde8a25693aeb6acf1af02b34d0156b/tesserocr.pyx#L1357)
```Cython
    def Init(self, path=_DEFAULT_PATH, lang=_DEFAULT_LANG, OcrEngineMode oem=OEM_DEFAULT):
```

... tesseract might have the correct path to the tessdata location, but an empty string as the language, which it isn't happy about at all.