### PR TITLE
fix _DEFAULT_PATH for tesseract >= dba13db

### DIFF
--- a/tesserocr.pyx
+++ b/tesserocr.pyx
@@ -48,7 +48,10 @@ setMsgSeverity(L_SEVERITY_NONE)  # suppress leptonica error messages
 cdef TessBaseAPI _api = TessBaseAPI()
 _api.SetVariable('debug_file', '/dev/null')  # suppress tesseract debug messages
 _api.Init(NULL, NULL)
-cdef _DEFAULT_PATH = abspath(join(_api.GetDatapath(), os.pardir)) + os.sep
+IF TESSERACT_VERSION >= 0x040000:
+    cdef _DEFAULT_PATH = _api.GetDatapath()  # "tessdata/" is not appended by tesseract since commit dba13db
+ELSE:
+    cdef _DEFAULT_PATH = abspath(join(_api.GetDatapath(), os.pardir)) + os.sep
 _init_lang = _api.GetInitLanguagesAsString()
 if _init_lang == '':
     _init_lang = 'eng'


### PR DESCRIPTION
A change for handling the tessdata path has been discussed here https://github.com/tesseract-ocr/tesseract/pull/1328 and finally implemented via https://github.com/tesseract-ocr/tesseract/pull/1356. Before this change, the path passed to tesseract was appended with `"tessdata/"` by first setting the variable `m_data_sub_dir` in

[tesseract/ccutil/ccutil.h#L80](https://github.com/tesseract-ocr/tesseract/blob/80f51c3758fa872d14c008bc75dc991daf0669b7/ccutil/ccutil.h#L80):

```c++
  STRING_VAR_H(m_data_sub_dir, "tessdata/", "Directory for data files");
```

and finally adding to the base path in

[tesseract/ccutil/mainblk.cpp#L104](https://github.com/tesseract-ocr/tesseract/blob/f0579380699c74ced74d1c64f23b602fc2517e0c/ccutil/mainblk.cpp#L104):

```c++
  datadir += m_data_sub_dir;     /**< data directory */
```

When tesserocr is looking for `_DEFAULT_PATH`, it caps the "tessdata/" from the path returned by tesseract simply to allow for it to be added back later by tesseract.

[tesserocr/tesserocr.pyx#L51](https://github.com/sirfz/tesserocr/blob/c6cf5d5f47dcb781224f5bdfb99bdd767371af5f/tesserocr.pyx#L51):
```cython
cdef _DEFAULT_PATH = abspath(join(_api.GetDatapath(), os.pardir)) + os.sep
```

However, since the changes in https://github.com/tesseract-ocr/tesseract/commit/9035217acd9c1d3c959e250735b66dbb2af6ccdf the path passed to tesseract by argument is now interpreted _as is_.

**Careful**, the changes proposed here will break builds with tesseract v4 before https://github.com/tesseract-ocr/tesseract/commit/9035217acd9c1d3c959e250735b66dbb2af6ccdf