### PR TITLE
Docker container to build tesserocr and run python from within it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.6.5-stretch
+MAINTAINER Sandeep Srinivasa "sss@lambdacurry.com"
+ENV DEBIAN_FRONTEND noninteractive
+
+
+RUN pip install Cython
+RUN pip install Pillow
+RUN apt-get update && apt-get install -y \
+    autoconf automake libtool \
+    rsync \
+    libpng-dev \
+    libjpeg-dev \
+    libtiff-dev \
+    zlib1g-dev
+RUN wget http://www.leptonica.org/source/leptonica-1.73.tar.gz -O /tmp/leptonica.tar.gz && tar -xvf /tmp/leptonica.tar.gz --directory /tmp
+ARG CACHE_DATE=2016-01-01
+WORKDIR /tmp/leptonica-1.73
+RUN ./configure && make &&  make install
+WORKDIR /tmp
+RUN wget https://github.com/tesseract-ocr/tesseract/archive/3.04.01.tar.gz -O /tmp/tesseract.tar.gz && tar -xvf /tmp/tesseract.tar.gz --directory /tmp
+WORKDIR /tmp/tesseract-3.04.01
+RUN ./autogen.sh && ./configure && LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\"-I/usr/local/include\" make &&  make install &&  ldconfig
+WORKDIR /tmp
+RUN wget https://github.com/tesseract-ocr/tessdata/archive/3.04.00.tar.gz -O /tmp/tessdata.tar.gz && tar -xvf /tmp/tessdata.tar.gz --directory /tmp
+RUN  mkdir -p /usr/local/share/tessdata/ &&  rsync -a tessdata-3.04.00/ /usr/local/share/tessdata
+RUN git clone https://github.com/sirfz/tesserocr.git 
+WORKDIR /tmp/tesserocr
+RUN python setup.py bdist_wheel
+RUN python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN ./autogen.sh && ./configure && LDFLAGS=\"-L/usr/local/lib\" CFLAGS=\"-I/usr/
 WORKDIR /tmp
 RUN wget https://github.com/tesseract-ocr/tessdata/archive/3.04.00.tar.gz -O /tmp/tessdata.tar.gz && tar -xvf /tmp/tessdata.tar.gz --directory /tmp
 RUN  mkdir -p /usr/local/share/tessdata/ &&  rsync -a tessdata-3.04.00/ /usr/local/share/tessdata
-RUN git clone https://github.com/sirfz/tesserocr.git 
+RUN mkdir /tmp/tesserocr
+
+ADD setup.py tesseract.pxd tesserocr_experiment.pyx tesserocr.pyx tests/ tox.ini /tmp/tesserocr
 WORKDIR /tmp/tesserocr
 RUN python setup.py bdist_wheel
 RUN python setup.py install


### PR DESCRIPTION
Hi,
I have added a Dockerfile that is able to build a docker container that does 4 things:
1. Compile a tesserocr installation from scratch
2. Run tests
3. Generate a wheel file
4. Can run the python interpreter directly (from the docker container) with tesserocr available.

P.S. you can also use this to run your Travis tests as well.

Building the docker container is simply 

> docker build --rm -t tesserocr .

Running python is simply

> docker run -i -t tesserocr python