### PR TITLE
Test against more tesseract versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: linux
 dist: trusty
-sudo: required
+sudo: false
 language: python
 python:
     - "2.7"
@@ -9,27 +9,16 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+env:
+    matrix:
+        - TESSERACT=3.04.01-1
+        - TESSERACT=3.05.02-3
 before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y autoconf automake libtool
-    - sudo apt-get install -y libpng12-dev
-    - sudo apt-get install -y libjpeg62-dev
-    - sudo apt-get install -y libtiff4-dev
-    - sudo apt-get install -y zlib1g-dev
-    - wget http://www.leptonica.org/source/leptonica-1.73.tar.gz -O /tmp/leptonica.tar.gz
-    - tar -xvf /tmp/leptonica.tar.gz
-    - pushd leptonica-1.73 && ./configure && make && sudo make install && popd
-    - wget https://github.com/tesseract-ocr/tesseract/archive/3.04.01.tar.gz -O /tmp/tesseract.tar.gz
-    - tar -xvf /tmp/tesseract.tar.gz
-    - cd tesseract-3.04.01
-    - ./autogen.sh && ./configure
-    - LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make
-    - sudo make install && sudo ldconfig
-    - cd ..
-    - wget https://github.com/tesseract-ocr/tessdata/archive/3.04.00.tar.gz -O /tmp/tessdata.tar.gz
-    - tar -xvf /tmp/tessdata.tar.gz 
-    - sudo mkdir -p /usr/local/share/tessdata/
-    - sudo rsync -a tessdata-3.04.00/ /usr/local/share/tessdata
+    - export TESSERACT_INSTALL=$HOME/.tesseract
+    - export TESSERACT_PKG=$TESSERACT_INSTALL/lib/pkgconfig
+    - export LD_LIBRARY_PATH=$TESSERACT_INSTALL/lib:$LD_LIBRARY_PATH
+    - export PKG_CONFIG_PATH=$TESSERACT_PKG:$PKG_CONFIG_PATH
+    - wget -O - https://github.com/nijel/tesseract-ocr-build/releases/download/$TESSERACT/tesseract.tar.xz | tar -C $HOME -xJf -
 install:
     - pip install Cython
     - pip install Pillow


### PR DESCRIPTION
- use prebuilt binaries from   https://github.com/nijel/tesseract-ocr-build
- no longer needs sudo on Travis CI
- currently 3.04.01 and 3.05.02 are tested

Currently it tests all combinations, what might be too much, please let me know if you want to reduce test matrix.