### PR TITLE
update tesseract version in travis, it may help the build pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     matrix:
         - TESSERACT=3.04.01-1
         - TESSERACT=3.05.02-3
-        - TESSERACT=4.0.0-beta.3-2
+        - TESSERACT=4.0.0-beta.4-1
 before_install:
     - export TESSERACT_INSTALL=$HOME/.tesseract
     - export TESSERACT_PKG=$TESSERACT_INSTALL/lib/pkgconfig


### PR DESCRIPTION
Update the tesseract to the last release. @nijel  already has the beta 4 binaries to Travis. This might heps tesserocr build with version 4 of tesseract to pass