### PR TITLE
Update Travis CI to Tesseract 4.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     matrix:
         - TESSERACT=3.04.01-1
         - TESSERACT=3.05.02-3
-        - TESSERACT=4.0.0-1
+        - TESSERACT=4.1.0-1
 before_install:
     - export TESSERACT_INSTALL=$HOME/.tesseract
     - export TESSERACT_PKG=$TESSERACT_INSTALL/lib/pkgconfig
@@ -28,7 +28,4 @@ install:
     - pip install Cython
     - pip install Pillow
 script:
-    - export LC_ALL=C
-    - export LC_CTYPE=C
-    - export LC_NUMERIC=C
     - python setup.py test


### PR DESCRIPTION
Tesseract 4.1.0 is the latest stable release.
It no longer requires setting the locale environment variables.

Signed-off-by: Stefan Weil <sw@weilnetz.de>