### PR TITLE
Don't use assignment operator for TessBaseAPI

### DIFF
--- a/tesserocr.pyx
+++ b/tesserocr.pyx
@@ -45,7 +45,7 @@ cdef bytes _b(s):
 
 # default parameters
 setMsgSeverity(L_SEVERITY_NONE)  # suppress leptonica error messages
-cdef TessBaseAPI _api = TessBaseAPI()
+cdef TessBaseAPI _api
 _api.SetVariable('debug_file', '/dev/null')  # suppress tesseract debug messages
 _api.Init(NULL, NULL)
 IF TESSERACT_VERSION >= 0x3999800:


### PR DESCRIPTION
It was deleted in latest Tesseract 5 and unnecessary for older Tesseract versions.

Signed-off-by: Stefan Weil <sw@weilnetz.de>