### PR TITLE
Access RowAttributes in PageIterator

### DIFF
--- a/tesseract.pxd
+++ b/tesseract.pxd
@@ -122,28 +122,73 @@ cdef extern from "tesseract/ocrclass.h" nogil:
         void set_deadline_msecs(int)
 
 cdef extern from "tesseract/pageiterator.h" namespace "tesseract" nogil:
-    cdef cppclass PageIterator:
-        void Begin()
-        void RestartParagraph()
-        bool IsWithinFirstTextlineOfParagraph() const
-        void RestartRow()
-        bool Next(PageIteratorLevel)
-        bool IsAtBeginningOf(PageIteratorLevel) const
-        bool IsAtFinalElement(PageIteratorLevel, PageIteratorLevel) const
-        void SetBoundingBoxComponents(bool, bool)
-        bool BoundingBox(PageIteratorLevel, const int, int *, int *, int *, int *) const
-        bool BoundingBoxInternal(PageIteratorLevel, int *, int *, int *, int *) const
-        bool Empty(PageIteratorLevel) const
-        PolyBlockType BlockType() const
-        Pta *BlockPolygon() const
-        Pix *GetBinaryImage(PageIteratorLevel) const
-        Pix *GetImage(PageIteratorLevel, int, Pix *, int *, int *) const
-        bool Baseline(PageIteratorLevel, int *, int *, int *, int *) const
-        void Orientation(TessOrientation *, TessWritingDirection *, TessTextlineOrder *, float *) const
-        void ParagraphInfo(TessParagraphJustification *, bool *, bool *, int *) const
+    IF TESSERACT_VERSION >= 0x4010200:
+        cdef cppclass PageIterator:
+            void Begin()
+            void RestartParagraph()
+            bool IsWithinFirstTextlineOfParagraph() const
+            void RestartRow()
+            bool Next(PageIteratorLevel)
+            bool IsAtBeginningOf(PageIteratorLevel) const
+            bool IsAtFinalElement(PageIteratorLevel, PageIteratorLevel) const
+            void SetBoundingBoxComponents(bool, bool)
+            bool BoundingBox(PageIteratorLevel, const int, int *, int *, int *, int *) const
+            bool BoundingBoxInternal(PageIteratorLevel, int *, int *, int *, int *) const
+            bool Empty(PageIteratorLevel) const
+            PolyBlockType BlockType() const
+            Pta *BlockPolygon() const
+            Pix *GetBinaryImage(PageIteratorLevel) const
+            Pix *GetImage(PageIteratorLevel, int, Pix *, int *, int *) const
+            bool Baseline(PageIteratorLevel, int *, int *, int *, int *) const
+            void Orientation(TessOrientation *, TessWritingDirection *, TessTextlineOrder *, float *) const
+            void ParagraphInfo(TessParagraphJustification *, bool *, bool *, int *) const
+            void RowAttributes(float *, float *, float *) const
+    ELSE:
+        cdef cppclass PageIterator:
+            void Begin()
+            void RestartParagraph()
+            bool IsWithinFirstTextlineOfParagraph() const
+            void RestartRow()
+            bool Next(PageIteratorLevel)
+            bool IsAtBeginningOf(PageIteratorLevel) const
+            bool IsAtFinalElement(PageIteratorLevel, PageIteratorLevel) const
+            void SetBoundingBoxComponents(bool, bool)
+            bool BoundingBox(PageIteratorLevel, const int, int *, int *, int *, int *) const
+            bool BoundingBoxInternal(PageIteratorLevel, int *, int *, int *, int *) const
+            bool Empty(PageIteratorLevel) const
+            PolyBlockType BlockType() const
+            Pta *BlockPolygon() const
+            Pix *GetBinaryImage(PageIteratorLevel) const
+            Pix *GetImage(PageIteratorLevel, int, Pix *, int *, int *) const
+            bool Baseline(PageIteratorLevel, int *, int *, int *, int *) const
+            void Orientation(TessOrientation *, TessWritingDirection *, TessTextlineOrder *, float *) const
+            void ParagraphInfo(TessParagraphJustification *, bool *, bool *, int *) const
 
 cdef extern from "tesseract/ltrresultiterator.h" namespace "tesseract" nogil:
-    IF TESSERACT_VERSION >= 0x4000000:
+    IF TESSERACT_VERSION >= 0x4010200:
+        cdef cppclass LTRResultIterator(PageIterator):
+            char *GetUTF8Text(PageIteratorLevel) const
+            void SetLineSeparator(cchar_t *)
+            void SetParagraphSeparator(cchar_t *)
+            float Confidence(PageIteratorLevel) const
+            cchar_t *WordFontAttributes(bool *, bool *, bool *, bool *, bool *, bool *, int *, int *) const
+            cchar_t *WordRecognitionLanguage() const
+            StrongScriptDirection WordDirection() const
+            bool WordIsFromDictionary() const
+            int BlanksBeforeWord() const
+            bool WordIsNumeric() const
+            bool HasBlamerInfo() const
+            cchar_t *GetBlamerDebug() const
+            cchar_t *GetBlamerMisadaptionDebug() const
+            bool HasTruthString() const
+            bool EquivalentToTruth(cchar_t *) const
+            char *WordTruthUTF8Text() const
+            char *WordNormedUTF8Text() const
+            cchar_t *WordLattice(int *) const
+            bool SymbolIsSuperscript() const
+            bool SymbolIsSubscript() const
+            bool SymbolIsDropcap() const
+    ELIF TESSERACT_VERSION >= 0x4000000:
         cdef cppclass LTRResultIterator(PageIterator):
             char *GetUTF8Text(PageIteratorLevel) const
             void SetLineSeparator(cchar_t *)

--- a/tesserocr.pyx
+++ b/tesserocr.pyx
@@ -771,6 +771,21 @@ cdef class PyPageIterator:
         self._piter.ParagraphInfo(&justification, &is_list_item, &is_crown, &first_line_indent)
         return justification, is_list_item, is_crown, first_line_indent
 
+    IF TESSERACT_VERSION >= 0x4010200:
+        def RowAttributes(self):
+            """Return row_height, descenders and ascenders in a dict"""
+            cdef:
+                float row_height
+                float descenders
+                float ascenders
+
+            self._piter.RowAttributes(&row_height, &descenders, &ascenders)
+            return {
+                'row_height': row_height,
+                'descenders': descenders,
+                'ascenders': ascenders
+            }
+
 
 cdef class PyLTRResultIterator(PyPageIterator):
 


### PR DESCRIPTION
Depends on https://github.com/tesseract-ocr/tesseract/pull/2971

Will allow fast access of RowAttributes without running a full `Recognize`, reducing the time to obtain such information by about a factor of 10.

The version test against `0x4010200` is preliminary and depends upon https://github.com/tesseract-ocr/tesseract/pull/2971

As `RowAttributes` is now part of `PageIterator`, it needs to be removed from `LTRResultIterator` to prevent ctypes from issuing an error about ambivalent overloads.