### PR TITLE
use BMP as fallback format (does not need external lib) instead of JPEG

### DIFF
--- a/tesserocr.pyx
+++ b/tesserocr.pyx
@@ -343,8 +343,8 @@ cdef _pix_to_image(Pix *pix):
     if fmt > 0:
         result = pixWriteMem(&buff, &size, pix, fmt)
     else:
-        # write as JPEG if format is unknown
-        result = pixWriteMemJpeg(&buff, &size, pix, 0, 0)
+        # write as IFF_BMP if format is unknown
+        result = pixWriteMem(&buff, &size, pix, 1)
 
     try:
         if result == 1:


### PR DESCRIPTION
leptonica support BMB directly , for jpeg support it need external library. When leptonica is built without JPEG support pixa_to_list fails silently 