### PR TITLE
Get model files for Tesseract from tagged release 4.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_install:
     - export LD_LIBRARY_PATH=$TESSERACT_INSTALL/lib:$LD_LIBRARY_PATH
     - export PKG_CONFIG_PATH=$TESSERACT_PKG:$PKG_CONFIG_PATH
     - wget -O - https://github.com/nijel/tesseract-ocr-build/releases/download/$TESSERACT/tesseract.tar.xz | tar -C $HOME -xJf -
-    - cd $TESSERACT_INSTALL/share/tessdata && rm -f osd.traineddata && wget https://github.com/tesseract-ocr/tessdata/raw/master/osd.traineddata && cd -
-    - cd $TESSERACT_INSTALL/share/tessdata && rm -f eng.traineddata && wget https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata && cd -
+    - cd $TESSERACT_INSTALL/share/tessdata && rm -f osd.traineddata && wget https://github.com/tesseract-ocr/tessdata/raw/4.1.0/osd.traineddata && cd -
+    - cd $TESSERACT_INSTALL/share/tessdata && rm -f eng.traineddata && wget https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata && cd -
 install:
     - pip install -U -r requirements-dev.txt
 script:

--- a/Windows.build.md
+++ b/Windows.build.md
@@ -91,8 +91,8 @@ Then:
 ```
     cd F:\Project
     git clone --depth 1 https://github.com/tesseract-ocr/tessconfigs tessdata
-    curl -L https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata --output F:\Project\tessdata\eng.traineddata
-    curl -L https://github.com/tesseract-ocr/tessdata/raw/master/osd.traineddata --output F:\Project\tessdata\osd.traineddata
+    curl -L https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata --output F:\Project\tessdata\eng.traineddata
+    curl -L https://github.com/tesseract-ocr/tessdata/raw/4.1.0/osd.traineddata --output F:\Project\tessdata\osd.traineddata
     SET TESSDATA_PREFIX=F:\Project\tessdata
 ```
 


### PR DESCRIPTION
The old URL no longer works because the default branches for Tesseract
now use "main" instead of "master".

It's also better for tesserocr to use a tagged release to get model files
instead of getting the latest development version.

Signed-off-by: Stefan Weil <sw@weilnetz.de>