### PR TITLE
docs: fix simple typo, instalation -> installation

### DIFF
--- a/Windows.build.md
+++ b/Windows.build.md
@@ -134,7 +134,7 @@ Then:
 
 ## Post installation
 
-Note: _adjust to you Python instalation_
+Note: _adjust to you Python installation_
 ```
     copy F:\win64\bin\*.dll "C:\Program Files\Python38\Lib\site-packages\"
 


### PR DESCRIPTION
There is a small typo in Windows.build.md.

Should read `installation` rather than `instalation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md