### PR TITLE
add github-workflow building wheels

### DIFF
--- a/.github/build-scripts/common-install-tesseract.sh
+++ b/.github/build-scripts/common-install-tesseract.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -ex
+
+LEPTONICA_VERSION="1.83.1"
+TESSERACT_VERSION="5.3.1"
+
+PREFIX="${PREFIX:-/usr/local}"
+
+curl -L -O "https://github.com/DanBloomberg/leptonica/releases/download/${LEPTONICA_VERSION}/leptonica-${LEPTONICA_VERSION}.tar.gz"
+
+tar -xzf leptonica-${LEPTONICA_VERSION}.tar.gz
+
+curl -L -o "tesseract-${TESSERACT_VERSION}.tar.gz" "https://github.com/tesseract-ocr/tesseract/archive/refs/tags/${TESSERACT_VERSION}.tar.gz"
+
+tar -xzf tesseract-${TESSERACT_VERSION}.tar.gz

--- a/.github/build-scripts/linux-install-tesseract.sh
+++ b/.github/build-scripts/linux-install-tesseract.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -ex
+
+source $(dirname -- "$0")/common-install-tesseract.sh
+
+# build leptonica
+cd leptonica-${LEPTONICA_VERSION}
+
+cmake \
+  -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DENABLE_GIF=OFF \
+  -DENABLE_JPEG=OFF \
+  -DENABLE_TIFF=OFF \
+  -DENABLE_WEBP=OFF \
+  -DENABLE_OPENJPEG=OFF
+
+cmake \
+  --build build \
+  --config Release \
+  --target install
+
+cd ..
+
+# build tesseract
+cd tesseract-${TESSERACT_VERSION}
+
+cmake \
+  -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DOPENMP_BUILD=OFF \
+  -DBUILD_TRAINING_TOOLS=OFF
+
+cmake \
+  --build build \
+  --config Release \
+  --target install
+
+cd ..

--- a/.github/build-scripts/macos-install-build-dependencies.sh
+++ b/.github/build-scripts/macos-install-build-dependencies.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -ex
+
+# leptonica dependencies
+brew install libpng zlib

--- a/.github/build-scripts/macos-install-tesseract.sh
+++ b/.github/build-scripts/macos-install-tesseract.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -ex
+
+source $(dirname -- "$0")/common-install-tesseract.sh
+
+# build leptonica
+cd leptonica-${LEPTONICA_VERSION}
+
+cmake \
+  -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
+  -DCMAKE_FIND_FRAMEWORK=NEVER \
+  -DBUILD_SHARED_LIBS=ON \
+  -DENABLE_GIF=OFF \
+  -DENABLE_JPEG=OFF \
+  -DENABLE_TIFF=OFF \
+  -DENABLE_WEBP=OFF \
+  -DENABLE_OPENJPEG=OFF
+
+cmake \
+  --build build \
+  --config Release \
+  --target install
+
+cd ..
+
+# build tesseract
+# see https://github.com/orgs/Homebrew/discussions/4031#discussioncomment-4348867
+export PKG_CONFIG_PATH=$(brew --prefix)/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH
+
+cd tesseract-${TESSERACT_VERSION}
+
+cmake \
+  -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
+  -DCMAKE_FIND_FRAMEWORK=NEVER \
+  -DBUILD_SHARED_LIBS=ON \
+  -DOPENMP_BUILD=OFF \
+  -DBUILD_TRAINING_TOOLS=OFF
+
+cmake \
+  --build build \
+  --config Release \
+  --target install
+
+cd ..

--- a/.github/build-scripts/manylinux-install-build-dependencies.sh
+++ b/.github/build-scripts/manylinux-install-build-dependencies.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -ex
+
+# leptonica dependencies
+yum install -y libpng-devel zlib-devel

--- a/.github/build-scripts/musllinux-install-build-dependencies.sh
+++ b/.github/build-scripts/musllinux-install-build-dependencies.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -ex
+
+# leptonica dependencies
+apk add libpng-dev zlib-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheel for ${{ matrix.config.platform }}
+
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - { os: ubuntu-22.04, arch: x86_64, platform: manylinux_x86_64 }
+          - { os: ubuntu-22.04, arch: x86_64, platform: musllinux_x86_64 }
+          - { os: macos-12,     arch: x86_64, platform: macosx_x86_64 }
+          - { os: macos-12,     arch: arm64,  platform: macosx_arm64}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build wheel
+        uses: pypa/cibuildwheel@v2.12.1
+        env:
+          CIBW_ARCHS: "${{ matrix.config.arch }}"
+          CIBW_BUILD: "cp*-${{ matrix.config.platform }}"
+          CIBW_SKIP: "cp36* cp37*"
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.cibuildwheel]
+build-verbosity = "1"
+
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.linux]
+before-all = [
+  "bash .github/build-scripts/manylinux-install-build-dependencies.sh",
+  "bash .github/build-scripts/linux-install-tesseract.sh",
+]
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = [
+  "bash .github/build-scripts/musllinux-install-build-dependencies.sh",
+  "bash .github/build-scripts/linux-install-tesseract.sh",
+]
+
+[tool.cibuildwheel.macos]
+before-all = [
+  "bash .github/build-scripts/macos-install-build-dependencies.sh",
+  "bash .github/build-scripts/macos-install-tesseract.sh",
+]


### PR DESCRIPTION
resolves #123 

Hello.

This PR adds a github-workflow to create wheels containing all the required libraries.
builds include:
- python: 3.8-3.11
- os: linux and macos

This now builds `leptonica` and `tesseract` from source.

~~some further information tho:
since `tesseract` and `leptonica` are being installed via `yum` (for `manylinux`), `apk` (for `musllinux`) and `brew` (for `macos`) all of the built wheels contain  a different version of tesseract.
that might pose a problem to some.
i think the only way to get around that would be to compile tesseract from source.~~