### PR TITLE
Add Python 3.12 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build wheel
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS: "${{ matrix.config.arch }}"
           CIBW_BUILD: "cp*-${{ matrix.config.platform }}"


### PR DESCRIPTION
- use latest pypa/cibuildwheel for Python 3.12 support