### PR TITLE
Build free-threaded compatible wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.config.arch }}"
           CIBW_BUILD: "${{ matrix.config.build }}-${{ matrix.config.platform }}"
+          CIBW_ENABLE: cpython-freethreading
           CIBW_SKIP: "cp36* cp37*"
 
       - name: Upload Artifacts


### PR DESCRIPTION
Hi, it is our understanding that this project already tries to avoid GIL-related issues with threading. Do we know if free-threaded Python 3.13 would improve things further?

@sirfz, would it be useful to check?