### PR TITLE
chore(ci): modernize wheel builds

### DIFF
--- a/.github/build-scripts/macos-install-tesseract.sh
+++ b/.github/build-scripts/macos-install-tesseract.sh
@@ -16,7 +16,7 @@ cmake \
   -DENABLE_GIF=OFF \
   -DENABLE_OPENJPEG=OFF
 
-cmake \
+sudo cmake \
   --build build \
   --config Release \
   --target install
@@ -39,7 +39,7 @@ cmake \
   -DOPENMP_BUILD=OFF \
   -DBUILD_TRAINING_TOOLS=OFF
 
-cmake \
+sudo cmake \
   --build build \
   --config Release \
   --target install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set macOS deployment target
+        if: runner.os == 'macOS'
+        run: echo "MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | cut -d '.' -f 1-2)" | tee -a $GITHUB_ENV
+
       - name: Build wheel
         uses: pypa/cibuildwheel@v2.22.0
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.config.arch }}"
           CIBW_BUILD: "${{ matrix.config.build }}-${{ matrix.config.platform }}"
-          CIBW_ENABLE: cpython-freethreading
           CIBW_SKIP: "cp36* cp37* cp38*"
 
       - name: Upload Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branches:
+      - "*"
+  pull_request:
 
   workflow_dispatch:
 
@@ -13,36 +16,26 @@ jobs:
 
     runs-on: ${{ matrix.config.os }}
     strategy:
+      fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-22.04, arch: x86_64, platform: manylinux_x86_64, build: cp*, tag: cpall }
-          - { os: ubuntu-22.04, arch: aarch64, platform: manylinux_aarch64, build: cp313, tag: cp313 }
-          - { os: ubuntu-22.04, arch: aarch64, platform: manylinux_aarch64, build: cp312, tag: cp312 }
-          - { os: ubuntu-22.04, arch: aarch64, platform: manylinux_aarch64, build: cp311, tag: cp311 }
-          - { os: ubuntu-22.04, arch: aarch64, platform: manylinux_aarch64, build: cp310, tag: cp310 }
-          - { os: ubuntu-22.04, arch: aarch64, platform: manylinux_aarch64, build: cp39, tag: cp39 }
-          - { os: ubuntu-22.04, arch: aarch64, platform: manylinux_aarch64, build: cp38, tag: cp38 }
-          - { os: ubuntu-22.04, arch: x86_64, platform: musllinux_x86_64, build: cp*, tag: cpall }
-          - { os: macos-12,     arch: x86_64, platform: macosx_x86_64, build: cp*, tag: cpall }
-          - { os: macos-12,     arch: arm64,  platform: macosx_arm64, build: cp*, tag: cpall }
+          - { os: ubuntu-24.04, arch: x86_64, platform: manylinux_x86_64, build: cp*, tag: cpall }
+          - { os: ubuntu-24.04-arm, arch: aarch64, platform: manylinux_aarch64, build: cp*, tag: cpall }
+          - { os: ubuntu-24.04, arch: x86_64, platform: musllinux_x86_64, build: cp*, tag: cpall }
+          - { os: macos-13,     arch: x86_64, platform: macosx_x86_64, build: cp*, tag: cpall }
+          - { os: macos-15,     arch: arm64,  platform: macosx_arm64, build: cp*, tag: cpall }
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Build wheel
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS: "${{ matrix.config.arch }}"
           CIBW_BUILD: "${{ matrix.config.build }}-${{ matrix.config.platform }}"
           CIBW_ENABLE: cpython-freethreading
-          CIBW_SKIP: "cp36* cp37*"
+          CIBW_SKIP: "cp36* cp37* cp38*"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- use native GitHub workers instead of relying on emulation
- update cibuildwheel
- trigger workflow on pullrequests and branches as well to have them CI checkecked