### PR TITLE
convert more exceptions

### DIFF
--- a/tesserocr/tesseract5.pxd
+++ b/tesserocr/tesseract5.pxd
@@ -146,7 +146,7 @@ cdef extern from "tesseract/pageiterator.h" namespace "tesseract" nogil:
 
 cdef extern from "tesseract/ltrresultiterator.h" namespace "tesseract" nogil:
     cdef cppclass LTRResultIterator(PageIterator):
-            char *GetUTF8Text(PageIteratorLevel) const
+            char *GetUTF8Text(PageIteratorLevel) except + # const (https://stackoverflow.com/a/29396365)
             void SetLineSeparator(cchar_t *)
             void SetParagraphSeparator(cchar_t *)
             float Confidence(PageIteratorLevel) const
@@ -172,7 +172,7 @@ cdef extern from "tesseract/ltrresultiterator.h" namespace "tesseract" nogil:
     cdef cppclass ChoiceIterator:
         ChoiceIterator(const LTRResultIterator &) except +
         bool Next()
-        cchar_t *GetUTF8Text() const
+        cchar_t *GetUTF8Text() except + # const (https://stackoverflow.com/a/29396365)
         float Confidence() const
 
 cdef extern from "tesseract/resultiterator.h" namespace "tesseract" nogil:
@@ -309,14 +309,14 @@ cdef extern from "tesseract/baseapi.h" namespace "tesseract" nogil:
             bool ProcessPages(cchar_t *, cchar_t *, int, TessResultRenderer *)
             bool ProcessPage(Pix *, int, cchar_t *, cchar_t *, int, TessResultRenderer *)
             ResultIterator *GetIterator()
-            char *GetUTF8Text()
+            char *GetUTF8Text() except +
             char *GetHOCRText(int)
             char *GetTSVText(int)
             char *GetBoxText(int)
             char *GetUNLVText()
             bool DetectOrientationScript(int *, float *, cchar_t **, float *)
             int MeanTextConf()
-            int *AllWordConfidences()
+            int *AllWordConfidences() except +
             bool AdaptToWordStr(PageSegMode, cchar_t *)
             void Clear()
             void End()


### PR DESCRIPTION
To be used in conjunction with https://github.com/tesseract-ocr/tesseract/pull/4420 – which hopefully will get merged in some form, ultimately.

There may be more functions that need exception conversion.

Example result:
```
15:36:15.156 ERROR ocrd.processor.base - Failure on page PHYS_0067: ELIST_ITERATOR::forward:Error:List would have returned a nullptr data pointer
Traceback (most recent call last):
  File "/data/ocr-d/ocrd_all/core/src/ocrd/processor/base.py", line 710, in process_workspace_handle_page_task
    task.result()
  File "/data/ocr-d/ocrd_all/core/src/ocrd/processor/base.py", line 124, in result
    return self.fn(*self.args, **self.kwargs)
  File "/data/ocr-d/ocrd_all/core/src/ocrd/processor/base.py", line 1157, in _page_worker
    _page_worker_processor.process_page_file(*input_files)
  File "/data/ocr-d/ocrd_all/core/src/ocrd/processor/base.py", line 809, in process_page_file
    result = self.process_page_pcgts(*input_pcgts, page_id=page_id)
  File "/data/ocr-d/ocrd_all/ocrd_tesserocr/ocrd_tesserocr/recognize.py", line 512, in process_page_pcgts
    self._process_existing_regions(regions, page_image, page_coords, pcgts.mapping)
  File "/data/ocr-d/ocrd_all/ocrd_tesserocr/ocrd_tesserocr/recognize.py", line 995, in _process_existing_regions
    self._process_existing_lines(textlines, region_image, region_coords, mapping)
  File "/data/ocr-d/ocrd_all/ocrd_tesserocr/ocrd_tesserocr/recognize.py", line 1059, in _process_existing_lines
    self._process_existing_words(words, line_image, line_coords, mapping)
  File "/data/ocr-d/ocrd_all/ocrd_tesserocr/ocrd_tesserocr/recognize.py", line 1095, in _process_existing_words
    word_conf = self.tessapi.AllWordConfidences()
  File "tesserocr.pyx", line 2386, in tesserocr.PyTessBaseAPI.AllWordConfidences
RuntimeError: ELIST_ITERATOR::forward:Error:List would have returned a nullptr data pointer
```

That is, there was a failed assertion in libtesseract, which now throws a C++ exception instead of hard `abort()`, so in Cython we could convert it to Python exception, which we can then catch and act on.
