### PR TITLE
Make AnalyseLayout interruptible

### DIFF
--- a/tesserocr/tesserocr.pyx
+++ b/tesserocr/tesserocr.pyx
@@ -2121,7 +2121,8 @@ cdef class PyTessBaseAPI:
             :class:`PyPageIterator`: Page iterator or `None` on error or an empty page.
         """
         cdef PageIterator *piter
-        piter = self._baseapi.AnalyseLayout(merge_similar_words)
+        with nogil:
+            piter = self._baseapi.AnalyseLayout(merge_similar_words)
         if piter == NULL:
             return None
         return PyPageIterator.createPageIterator(piter)


### PR DESCRIPTION
In some pathological cases, Tesseract can take extremely long for layout analysis. See [this discussion](https://github.com/tesseract-ocr/tesseract/issues/3377).

I observed that this long computation cannot be interrupted or timed in any way (not even with SIGINT). Nothing short of killing the process works (as ctrl+c does on the shell – but not from Python). At least as long as it is using `AnalyseLayout` rather than `Recognize`. The only difference seems to be: The latter runs without the GIL, but the former does not. 

This change makes `AnalyseLayout` as interruptible as `Recognize` based on my tests.