### PR TITLE
Catch exception in get_languages()

### DIFF
--- a/tesserocr/tesseract5.pxd
+++ b/tesserocr/tesseract5.pxd
@@ -282,7 +282,7 @@ cdef extern from "tesseract/baseapi.h" namespace "tesseract" nogil:
             int Init(cchar_t *, cchar_t *)
             cchar_t *GetInitLanguagesAsString() const
             void GetLoadedLanguagesAsVector(vector[string] *) const
-            void GetAvailableLanguagesAsVector(vector[string] *) const
+            void GetAvailableLanguagesAsVector(vector[string] *) except +
             void InitForAnalysePage()
             void ReadConfigFile(cchar_t *)
             void SetPageSegMode(PageSegMode)

--- a/tesserocr/tesserocr.pyx
+++ b/tesserocr/tesserocr.pyx
@@ -2815,7 +2815,11 @@ def get_languages(path=_DEFAULT_PATH):
             int i
     baseapi.Init(py_path, NULL)
     path = baseapi.GetDatapath()
-    baseapi.GetAvailableLanguagesAsVector(&v)
+    try:
+        baseapi.GetAvailableLanguagesAsVector(&v)
+    except RuntimeError:
+        baseapi.End()
+        raise
     langs = [v[i].c_str() for i in range(v.size())]
     baseapi.End()
     return path, langs


### PR DESCRIPTION
Passing a non-existent path to get_languages() ends up with a core dump.

```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: recursive directory iterator cannot open directory: No such file or directory [none/]
------------------------------------------------------------------------
...
------------------------------------------------------------------------
Unhandled SIGABRT: An abort() occurred.
This probably occurred because a *compiled* module has a bug
in it and is not properly wrapped with sig_on(), sig_off().
Python will now terminate.
------------------------------------------------------------------------
Aborted                    (core dumped) python
```