### PR TITLE
Fix test_init_full box.train file_type

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include LICENSE
 include tesserocr/*.pyx
 include tesserocr/*.pxd
 include tesserocr/*.pyi
-include tests/*.py tests/*.png
+include tests/*.py tests/*.png tests/*.train
 exclude tesserocr/*.cpp
 exclude tesserocr/*.so
 exclude *.so

--- a/tests/box.train
+++ b/tests/box.train
@@ -1,0 +1,12 @@
+disable_character_fragments T
+file_type                   .bl
+textord_fast_pitch_test	T
+tessedit_zero_rejection T
+tessedit_minimal_rejection F
+tessedit_write_rep_codes F
+edges_children_fix F
+edges_childarea 0.65
+edges_boxarea 0.9
+tessedit_resegment_from_boxes T
+tessedit_train_from_boxes T
+textord_no_rejects T

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,6 +48,7 @@ _TESSERACT_VERSION = version_to_int(tesserocr.PyTessBaseAPI.Version())
 class TestTessBaseApi(unittest.TestCase):
 
     _test_dir = os.path.abspath(os.path.dirname(__file__))
+    _config_file = os.path.join(_test_dir, "box.train")
     _image_file = os.path.join(_test_dir, "eurotext.png")
 
     def setUp(self):
@@ -77,13 +78,13 @@ class TestTessBaseApi(unittest.TestCase):
         self.assertEqual(self._api.GetVariableAsString("file_type"), ".tif")
         self.assertEqual(self._api.GetVariableAsString("edges_childarea"), "0.5")
         # use box.train config variables
-        configs = ["box.train"]
+        configs = [self._config_file]
         # change edges_childarea
         vars_ = {"edges_childarea": "0.7"}
         self._api.End()
         self._api.InitFull(configs=configs, variables=vars_)
         # assert file_type from box.train and custom edges_childarea
-        self.assertEqual(self._api.GetVariableAsString("file_type"), ".tif")
+        self.assertEqual(self._api.GetVariableAsString("file_type"), ".bl")
         self.assertEqual(self._api.GetVariableAsString("edges_childarea"), "0.7")
         # reset back to default
         self._api.End()


### PR DESCRIPTION
FAILED tests/test_api.py::TestTessBaseApi::test_init_full - AssertionError: '.bl' != '.tif'

---

```
file_type                   .bl
```

https://github.com/tesseract-ocr/tessconfigs/blob/3decf1c8252ba6dbeef0bf908f4b0aab7f18d113/configs/box.train#L2
